### PR TITLE
enhance file lock management in AppendOnlyFSBucket tests

### DIFF
--- a/python/tests/bucket_tester.py
+++ b/python/tests/bucket_tester.py
@@ -10,6 +10,7 @@ from pathlib import Path, PurePosixPath
 from queue import Queue
 from typing import BinaryIO
 from unittest import TestCase
+import uuid
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -87,7 +88,7 @@ class IBucketTester:  # pylint: disable=too-many-public-methods
         self.storage = storage
         self.test_case = test_case
         # Next is a unique suffix to be used in the names of dirs and files, so they will be unique
-        self.us = f"{iTSms.now() % 100_000_000:08d}"
+        self.us = uuid.uuid4().hex
 
     def cleanup(self) -> None:
         self.storage.remove_prefix(f"dir{self.us}")

--- a/python/tests/test_append_only_fs_bucket.py
+++ b/python/tests/test_append_only_fs_bucket.py
@@ -46,7 +46,9 @@ class TestAppendOnlyFSBucket(unittest.TestCase):
         bucket_in_test.put_object(object_name, content)
 
         verifier_manager = FileLockManager(self.locks_path)
-        self.assertTrue(verifier_manager.get_lock(object_name).acquire(timeout=0.1), "Lock should have been released after put_object")
+        v_lock = verifier_manager.get_lock(object_name)
+        self.assertTrue(v_lock.acquire(timeout=0.1), "Lock should have been released after put_object")
+        v_lock.release()
         self.assertEqual(base_bucket_put_calls, [(object_name, content)])
 
     def test_put_object_twice_raises_exception(self):
@@ -96,7 +98,9 @@ class TestAppendOnlyFSBucket(unittest.TestCase):
             verifier_manager.get_lock(object_name).acquire(timeout=0.1)
 
         bucket_in_test._unlock_object(object_name)
-        self.assertTrue(verifier_manager.get_lock(object_name).acquire(timeout=0.1), "Lock should have been released after _unlock_object")
+        v_lock = verifier_manager.get_lock(object_name)
+        self.assertTrue(v_lock.acquire(timeout=0.1), "Lock should have been released after _unlock_object")
+        v_lock.release()
 
     def test_unlocking_unlocked_object_raises_assertion(self):
         bucket_in_test = AppendOnlyFSBucket(self.base_bucket, self.locks_path)

--- a/python/tests/test_namedlock.py
+++ b/python/tests/test_namedlock.py
@@ -72,6 +72,7 @@ class FileLockManagerTests(unittest.TestCase):
         lock2.acquire()
 
         verifier_manager = FileLockManager(self.temp_dir)
+        # We expect TimeoutError because filelock.Timeout is a subclass of it.
         with self.assertRaises(TimeoutError):
             verifier_manager.get_lock(name1).acquire(timeout=0.1)
         with self.assertRaises(TimeoutError):
@@ -80,10 +81,12 @@ class FileLockManagerTests(unittest.TestCase):
         lock1.release()
         lock2.release()
 
-        self.assertTrue(verifier_manager.get_lock(name1).acquire(timeout=0.1))
-        verifier_manager.get_lock(name1).release()
-        self.assertTrue(verifier_manager.get_lock(name2).acquire(timeout=0.1))
-        verifier_manager.get_lock(name2).release()
+        v_lock1 = verifier_manager.get_lock(name1)
+        self.assertTrue(v_lock1.acquire(timeout=0.1))
+        v_lock1.release()
+        v_lock2 = verifier_manager.get_lock(name2)
+        self.assertTrue(v_lock2.acquire(timeout=0.1))
+        v_lock2.release()
 
     def test_lock_directory_created(self):
         # Delete the directory to test creation


### PR DESCRIPTION
### Title
Enhances file lock management testing with more robust lock acquisition verification. 

### Ticket / Task
somewhat relalted https://github.com/eSAMTrade/bucketbase/pull/164

### What & Why
This PR enhances file lock management testing in AppendOnlyFSBucket by replacing file existence checks with more robust lock acquisition verification. Instead of simply checking if lock files exist or don't exist, the tests now verify that locks can actually be acquired (when they should be released) or cannot be acquired (when they should be held).

solves the CI issues we've been having.


### Scope
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor / tech-debt
- [x] Test / tooling only

### Checklist (self-review)
See Section 5.

### Risk / Impact
- Latency critical path?  ☐ Yes  [x] No
- External API contract change? ☐ Yes  [x] No
- Migration steps required?  ☐ Yes  [x] No

### Screenshots / Logs / Benchmarks
(only if relevant)

### Author Self-Review Checklist
- [ ] **Single Ticket** — PR addresses only one business requirement / Trello card.
- [x] **Minimal Diff** — no unrelated refactors, commented-out code, or debug prints.
- [x] **Compiles & Tests Pass** — `pytest -q` / `mvn test` clean locally.
- [ ] **No Dead Code** — every new unit is called or covered by tests.
- [ ] **Naming & Clarity** — identifiers are self-explanatory; no overloaded meanings.
- [ ] **Docs Updated** — README, wiki, or docstrings updated where behaviour changed.
- [ ] **Performance Tagged** — if touching hot path, attach micro-benchmarks or profiler diff.
- [x] **Config & Secrets** — no plaintext credentials; configs externalised.
- [x] **Rollback Ready** — change can be reverted with `git revert` without dependency hell.
- [x] **Checklist Acknowledged** — I would merge this myself if I were the reviewer.
- [x] **LLM Review** — PR has been reviewed by the approved LLM tool and suggestions addressed.
    - [ ] **IDE Type Checker** — PyCharm/Pylance recommendations were addressed where applicable.
    - [ ] **Optional mypy** — (Recommended) Ran `python/scripts/run_mypy.bat` locally with no critical errors

### Resources:
- [PR guidelines](https://wiki.esamtrade.com/en/engineering/pr-guidelines)